### PR TITLE
Remove duplicate register_title entry

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -37,7 +37,6 @@
   "auth": {
     "loginTitle": "Welcome back",
     "registerTitle": "Create an account",
-    "register_title": "Create an account",
     "register_subtitle": "Join Verzot to start organizing tournaments",
     "email": "Email",
     "emailRequired": "Email is required",


### PR DESCRIPTION
## Summary
- trim duplicate `register_title` key from English locale

## Testing
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68413f2b6a448322b05418cd47d1b3d3